### PR TITLE
Rename Cell1DatasetsTest → Cell1DDatasetsTest

### DIFF
--- a/graphene/graphene/src/test/java/org/diirt/graphene/Cell1DDatasetsTest.java
+++ b/graphene/graphene/src/test/java/org/diirt/graphene/Cell1DDatasetsTest.java
@@ -16,7 +16,7 @@ import static org.hamcrest.Matchers.*;
  *
  * @author carcassi
  */
-public class Cell1DatasetsTest {
+public class Cell1DDatasetsTest {
 
     @Test
     public void linearRange1() {


### PR DESCRIPTION
Test class name is incorrect w.r.t. class under test.
