### PR TITLE
graphene: fix a couple of issues in FontUtil

### DIFF
--- a/graphene/graphene/src/main/java/org/diirt/graphene/FontUtil.java
+++ b/graphene/graphene/src/main/java/org/diirt/graphene/FontUtil.java
@@ -20,12 +20,12 @@ public class FontUtil {
     
     private static Font loadFont(String name) {
         try {
-            Font font = Font.createFont(Font.TRUETYPE_FONT, HorizontalAxisRenderer.class.getResourceAsStream("LiberationSans-Regular.ttf"));
+            Font font = Font.createFont(Font.TRUETYPE_FONT, FontUtil.class.getResourceAsStream(name));
             return font.deriveFont(Font.PLAIN, 10);
         } catch (FontFormatException ex) {
-            Logger.getLogger(HorizontalAxisRenderer.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(FontUtil.class.getName()).log(Level.SEVERE, null, ex);
         } catch (IOException ex) {
-            Logger.getLogger(HorizontalAxisRenderer.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(FontUtil.class.getName()).log(Level.SEVERE, null, ex);
         }
         throw new RuntimeException("Couldn't load");
     }

--- a/graphene/graphene/src/test/java/org/diirt/graphene/FontUtilTest.java
+++ b/graphene/graphene/src/test/java/org/diirt/graphene/FontUtilTest.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * All rights reserved. Use is subject to license terms. See LICENSE.TXT
+ */
+package org.diirt.graphene;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.awt.Font;
+
+import org.junit.Test;
+
+public class FontUtilTest {
+
+    @Test
+    public void loadRegularFont() {
+        final Font font = FontUtil.getLiberationSansRegular();
+        assertNotNull(font);
+    }
+
+}


### PR DESCRIPTION
1. `FontUtil` had several references to `HorizontalAxisRenderer` - `FontUtil` is more appropriate
2. The `name` parameter to `loadFont` was unused

Also add a minimal unit test for this class.
