### PR TITLE
Fix race-condition in type-support installation

### DIFF
--- a/pvmanager/datasource-vtype/src/main/java/org/diirt/datasource/vtype/DataTypeSupport.java
+++ b/pvmanager/datasource-vtype/src/main/java/org/diirt/datasource/vtype/DataTypeSupport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2010-14 diirt developers. See COPYRIGHT.TXT
+ * Copyright (C) 2010-17 diirt developers. See COPYRIGHT.TXT
  * All rights reserved. Use is subject to license terms. See LICENSE.TXT
  */
 package org.diirt.datasource.vtype;
@@ -15,7 +15,8 @@ import org.diirt.datasource.TypeSupport;
  */
 public final class DataTypeSupport {
 
-    private static boolean installed = false;
+    private static volatile boolean installed = false;
+    private static final Object installLock = new Object();
 
     /**
      * Installs type support. This should only be called by either DataSources
@@ -27,10 +28,22 @@ public final class DataTypeSupport {
             return;
         }
 
-        // Add notification support for all immutable types
-        TypeSupport.addTypeSupport(NotificationSupport.immutableTypeSupport(VType.class));
+        // This looks like double-checked locking and in fact it is, but it is
+        // safe because installed is volatile.
+        // If we used an AtomicBoolean instead of the volatile boolean, we would
+        // not need the lock (we could use a compare-and-set operation), but in
+        // this case another thread calling this method might return before the
+        // installation has actually finished.
+        synchronized (installLock) {
+            if (installed) {
+                return;
+            }
 
-        installed = true;
+            // Add notification support for all immutable types
+            TypeSupport.addTypeSupport(NotificationSupport.immutableTypeSupport(VType.class));
+
+            installed = true;
+        }
     }
 
     /**


### PR DESCRIPTION
There were two problems with how `TypeSupport`s where added to the global `TypeSupport` object:

1. The code in `TypeSupport` incorrectly ued `ConcurrentHashMap`s. It used a `get(…)`, followed by a `put(…)`, which does not guarantee atomicty. This code has been changed to use `putIfAbsent(…)`, which is guaranteed to be atomic. There also was a minor problem with how the map of calculated type-supports was cleared that has been fixed now.

2. The `install()` methods in `org.diirt.datasource.BasicTypeSupport` and `org.diirt.datasource.vtype.DataTypeSupport` were prone to a race condition. This has been fixed now by adding a lock that ensures that only one thread installs the type supports. This lock is only taken when the type support has not been installed yet, so performance implications should be negligible. The `installed` flag in the VType `DataTypeSupport` class also lacked the `volatile` flag, which has now been added.

It might first look like the second problem was not a problem at all because `install()` is only called from static initializers. However, the JLS only guarantees that the static initializer *of the same class* is only executed by a single thread. As the `install()` method is called from the static initializers in different classes, two threads might call it concurrently if these classes are loaded by two different threads.