### PR TITLE
Avoid race condition when creating data source

### DIFF
--- a/pvmanager/datasource/src/main/java/org/diirt/datasource/CompositeDataSource.java
+++ b/pvmanager/datasource/src/main/java/org/diirt/datasource/CompositeDataSource.java
@@ -233,8 +233,13 @@ public class CompositeDataSource extends DataSource {
                 if (dataSource == null) {
                     throw new IllegalStateException("DataSourceProvider '" + name + conf.delimiter + "' did not create a valid datasource.");
                 }
-                dataSources.put(name, dataSource);
-                log.log(Level.CONFIG, "Created instance for data source {0} ({1})", new Object[]{name, dataSource.getClass().getSimpleName()});
+                DataSource existingDataSource = dataSources.putIfAbsent(name, dataSource);
+                if (existingDataSource != null) {
+                    dataSource.close();
+                    dataSource = existingDataSource;
+                } else {
+                    log.log(Level.CONFIG, "Created instance for data source {0} ({1})", new Object[]{name, dataSource.getClass().getSimpleName()});
+                }
             }
         }
         return dataSource;


### PR DESCRIPTION
There was a race condition in `CompositeDataSource` that could lead to two data sources being created for the same name.

This could lead to exceptions like the following (I actually saw these in CSS):

```
2019-02-04 17:05:33.766 WARNING [Thread 25] org.diirt.datasource.DataSource (disconnectRead) - ChannelReadRecipe [ChannelReadRecipe for Test:01:Stop.PROC: org.diirt.datasource.ChannelHandlerReadSubscription@6385b363] was disconnected but was never connected. Ignoring it.
```
or
```
2019-02-04 17:08:19.022 WARNING [Thread 31] org.diirt.datasource.DataSource (disconnectWrite) - ChannelWriteRecipe org.diirt.datasource.ChannelWriteRecipe@2e4b1a76 was unregistered but was never registered. Ignoring it.
```

This PR fixes this issue. While it can still happen, that two data sources for the same name are created (this could only be avoided by introducing a mutex, which might have other implications like potential dead-locks, etc.), if a second data source is created, it is closed immediately and never used. This should be sufficient to avoid the exceptions listed above.